### PR TITLE
최상위 부모 추상 클래스 Charactor 구현, 생존자 저장방식 Dictionary로 변경, 구조맨 스킬 구현

### DIFF
--- a/Assets/Resources/Prefabs/panicRescueTarget.prefab
+++ b/Assets/Resources/Prefabs/panicRescueTarget.prefab
@@ -72,8 +72,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23f89c18c64f23f4989bbc353d3a147b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _maxo2: 0
+  _useo2: 0
+  _maxHp: 0
   HPGage: {fileID: 7042168152952561195}
-  RTTile: {fileID: 0}
+  SmileMark: {fileID: 7160356350746327719}
 --- !u!1 &4662694992756842750
 GameObject:
   m_ObjectHideFlags: 0
@@ -347,7 +350,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5639435013827214143
 RectTransform:
   m_ObjectHideFlags: 0
@@ -382,7 +385,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7160356350746327719}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 

--- a/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
@@ -1,34 +1,22 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
-public abstract class Charactor : MonoBehaviour
-{
+public abstract class Charactor : MonoBehaviour {
     [SerializeField]
-    protected float _maxo2 = 0.0f; // 캐릭터 최대 산소량
-    protected float _currento2 = 0.0f; // 캐릭터 현재 산소량
+    protected Image HPGage; // 체력
     [SerializeField]
-    protected float _useo2 = 0.0f; // 1초에 사용되는 산소량
-    [SerializeField]
-    protected float _maxHp = 0.0f; // 최대 체력
-    protected float _currentHp = 0.0f; // 현재 체력
+    protected Image O2Gage; // 산소
 
-    public float MaxO2 // O2 Property
-    {
-        get { return _maxo2; }
-    }
-    public float CurrentO2 // 현재 O2 Property
-    {
-        get { return _currento2; }
-    }
-    public float MaxHP
-    {
-        get { return _maxHp; }
-    }
-    public float CurrentHP
-    {
-        get { return _currentHp; }
-    }
+    [SerializeField]
+    private float _maxo2 = 0.0f; // 캐릭터 최대 산소량
+    private float _currento2 = 0.0f; // 캐릭터 현재 산소량
+    [SerializeField]
+    private float _useo2 = 0.0f; // 1초에 사용되는 산소량
+    [SerializeField]
+    private float _maxHp = 0.0f; // 최대 체력
+    private float _currentHp = 0.0f; // 현재 체력
 
     protected virtual void Start()
     {
@@ -38,17 +26,41 @@ public abstract class Charactor : MonoBehaviour
 
     public virtual void AddHP(float value) {
         _currentHp += value;
-        if (_currentHp < 0)
+
+        if (CurrentHP < 0)
             _currentHp = 0;
-        else if (_currentHp > _maxHp)
-            _currentHp = _maxHp;
+        else if (CurrentHP > MaxHP)
+            _currentHp = MaxHP;
+
+        if (HPGage != null)
+            HPGage.fillAmount = CurrentHP / MaxHP; // 체력 UI 변화
     }
 
     public virtual void AddO2(float value) {
         _currento2 += value;
-        if (_currento2 < 0)
+
+        if (CurrentO2 < 0)
             _currento2 = 0;
-        else if (_currento2 > _maxo2)
-            _currento2 = _maxo2;
+        else if (CurrentO2 > MaxO2)
+            _currento2 = MaxO2;
+
+        if (O2Gage != null)
+            O2Gage.fillAmount = CurrentO2 / MaxO2; // 산소 UI 변화
+    }
+
+    public float MaxO2 {
+        get { return _maxo2; }
+    }
+    public float CurrentO2 {
+        get { return _currento2; }
+    }
+    public float UseO2 {
+        get { return _useo2; }
+    }
+    public float MaxHP {
+        get { return _maxHp; }
+    }
+    public float CurrentHP {
+        get { return _currentHp; }
     }
 }

--- a/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
@@ -36,6 +36,19 @@ public abstract class Charactor : MonoBehaviour
         _currentHp = _maxHp;
     }
 
-    public abstract void SetCurrentHP(float value);
-    public abstract void SetCurrentO2(float value);
+    public virtual void AddHP(float value) {
+        _currentHp += value;
+        if (_currentHp < 0)
+            _currentHp = 0;
+        else if (_currentHp > _maxHp)
+            _currentHp = _maxHp;
+    }
+
+    public virtual void AddO2(float value) {
+        _currento2 += value;
+        if (_currento2 < 0)
+            _currento2 = 0;
+        else if (_currento2 > _maxo2)
+            _currento2 = _maxo2;
+    }
 }

--- a/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class Charactor : MonoBehaviour
+{
+    [SerializeField]
+    protected float _maxo2 = 0.0f; // 캐릭터 최대 산소량
+    protected float _currento2 = 0.0f; // 캐릭터 현재 산소량
+    [SerializeField]
+    protected float _useo2 = 0.0f; // 1초에 사용되는 산소량
+    [SerializeField]
+    protected float _maxHp = 0.0f; // 최대 체력
+    protected float _currentHp = 0.0f; // 현재 체력
+
+    public float MaxO2 // O2 Property
+    {
+        get { return _maxo2; }
+    }
+    public float CurrentO2 // 현재 O2 Property
+    {
+        get { return _currento2; }
+    }
+    public float MaxHP
+    {
+        get { return _maxHp; }
+    }
+    public float CurrentHP
+    {
+        get { return _currentHp; }
+    }
+
+    protected virtual void Start()
+    {
+        _currento2 = _maxo2;
+        _currentHp = _maxHp;
+    }
+
+    public abstract void SetCurrentHP(float value);
+    public abstract void SetCurrentO2(float value);
+}

--- a/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs.meta
+++ b/Assets/Resources/Script/PlayScene/Charactor/Charactor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6498d23e91f666c4eb020062fd6618a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Script/PlayScene/Charactor/HammerMan.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/HammerMan.cs
@@ -23,7 +23,7 @@ public class HammerMan : Player
     public override void ActiveSkill()
     {
         base.ActiveSkill();
-        if(_currento2 > 10) // 현재 산소가 10 이상있다면
+        if (CurrentO2 > 10) // 현재 산소가 10 이상있다면
         {
             StartCoroutine(RescueHammer()); // 스킬 발동
         }
@@ -42,8 +42,7 @@ public class HammerMan : Player
                 if (GameMgr.Instance.Obstacle.GetTile(oPos) != null) // 클릭 좌표에 장애물이 있다면 제거
                 {
                     GameMgr.Instance.Obstacle.SetTile(oPos, null);
-                    _currento2 -= 10;
-                    O2Gage.fillAmount = _currento2 / _maxo2; // 산소 UI 변화
+                    AddO2(-10);
                     if (GameMgr.Instance.RescueTilemap.GetTile(oPos - GameMgr.Instance.RescueTilemap.WorldToCell(transform.position)) != null)
                     {
                         _playerAct = _Act.Panic; // 턴제한 추가 필요

--- a/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
@@ -28,7 +28,7 @@ public class Nurse : Player
     public override void ActiveSkill()
     {
         base.ActiveSkill();
-        if (_currento2 > 15) // 현재 산소가 10 이상있다면
+        if (CurrentO2 > 15) // 현재 산소가 10 이상있다면
         {
             StartCoroutine(Heal()); // 스킬 발동
         }
@@ -50,10 +50,7 @@ public class Nurse : Player
                     {
                         player.AddHP(30.0f);
                         player.AddO2(20.0f);
-                        player.HPGage.fillAmount = player.CurrentHP / player.MaxHP;
-                        player.O2Gage.fillAmount = player.CurrentO2 / player.MaxO2;
-                        _currento2 -= 15;
-                        O2Gage.fillAmount = _currento2 / _maxo2;
+                        AddO2(-15);
                         break;
                     }
                 }

--- a/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
@@ -48,16 +48,8 @@ public class Nurse : Player
                 {
                     if(player.currentTilePos == oPos)
                     {
-                        player.CurrentHP += 30;
-                        player.CurrentO2 += 20;
-                        if(player.CurrentHP > player.MaxHP)
-                        {
-                            player.CurrentHP = player.MaxHP;
-                        }
-                        if(player.CurrentO2 > player.MaxO2)
-                        {
-                            player.CurrentO2 = player.MaxO2;
-                        }
+                        player.SetCurrentHP(30.0f);
+                        player.SetCurrentO2(20.0f);
                         player.HPGage.fillAmount = player.CurrentHP / player.MaxHP;
                         player.O2Gage.fillAmount = player.CurrentO2 / player.MaxO2;
                         _currento2 -= 15;

--- a/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Nurse.cs
@@ -48,8 +48,8 @@ public class Nurse : Player
                 {
                     if(player.currentTilePos == oPos)
                     {
-                        player.SetCurrentHP(30.0f);
-                        player.SetCurrentO2(20.0f);
+                        player.AddHP(30.0f);
+                        player.AddO2(20.0f);
                         player.HPGage.fillAmount = player.CurrentHP / player.MaxHP;
                         player.O2Gage.fillAmount = player.CurrentO2 / player.MaxO2;
                         _currento2 -= 15;

--- a/Assets/Resources/Script/PlayScene/Charactor/Player.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Player.cs
@@ -87,13 +87,13 @@ public class Player : Charactor
             }
             if (hor != 0.0f) // 좌, 우 이동중이라면
             {
-                SetCurrentO2(-(_useo2 * Time.deltaTime));
+                AddO2(-(_useo2 * Time.deltaTime));
                 GameMgr.Instance.EmberTime += Time.deltaTime / 2; // 작은불 재생성 시간 증가
                 _moveDir = new Vector3(hor, 0, 0); // 바라보는 방향 변경
             }
             if (ver != 0.0f) //상, 하 이동중이라면
             {
-                SetCurrentO2(-(_useo2 * Time.deltaTime));
+                AddO2(-(_useo2 * Time.deltaTime));
                 GameMgr.Instance.EmberTime += Time.deltaTime / 2; // 작은불 재생성 시간 증가
             }
             //if (_currentTilePos != _tileLayout.WorldToCell(transform.position))
@@ -176,7 +176,7 @@ public class Player : Charactor
 
     public virtual void TurnEndActive() // 캐릭터가 턴이 끝날 때 호출되는 함수
     {
-        SetCurrentO2(10.0f);
+        AddO2(10.0f);
         if(_playerAct == _Act.Rescue) // 구조중이라면
         {
             _rescueTarget.RescueCount--; // 구조중인 대상의 남은 구조턴 감소
@@ -323,25 +323,25 @@ public class Player : Charactor
 
     private void UseO2Can() // 산소캔 사용
     {
-        SetCurrentO2(45.0f);
+        AddO2(45.0f);
     }
 
     protected virtual void OnTriggerEnter2D(Collider2D other) { // 충돌체크
         switch (other.tag) {
         case "Fire": // 큰 불
-            SetCurrentHP(-25.0f); // 체력 감소
-            SetCurrentMental(-2); // 멘탈 감소
+            AddHP(-25.0f); // 체력 감소
+            AddMental(-2); // 멘탈 감소
             break;
 
         case "Ember": // 작은 불
-            SetCurrentHP(-10.0f); // 체력 감소
-            SetCurrentMental(-1); // 멘탈 감소
+            AddHP(-10.0f); // 체력 감소
+            AddMental(-1); // 멘탈 감소
             break;
 
         case "Electric":
         case "Water(Electric)":
-            SetCurrentHP(-35.0f); // 체력 감소
-            SetCurrentMental(-2); // 멘탈 감소
+            AddHP(-35.0f); // 체력 감소
+            AddMental(-2); // 멘탈 감소
             break;
         }
 
@@ -420,33 +420,23 @@ public class Player : Charactor
         }
     }
 
-    public override void SetCurrentHP(float value)
+    public override void AddHP(float value)
     {
-        _currentHp += value;
-        if(_currentHp <= 0 )
-        {
+        base.AddHP(value);
+
+        if (CurrentHP <= 0 )
             _playerAct = _Act.Retire;
-        }
-        else if(_currentHp > _maxHp)
-        {
-            _currentHp = _maxHp;
-        }
     }
 
-    public override void SetCurrentO2(float value)
+    public override void AddO2(float value)
     {
-        _currento2 += value;
-        if(_currento2 <= 0)
-        {
+        base.AddO2(value);
+
+        if (CurrentO2 <= 0)
             _playerAct = _Act.Retire;
-        }
-        else if(_currento2 > _maxo2)
-        {
-            _currento2 = _maxo2;
-        }
     }
 
-    private void SetCurrentMental(int value)
+    private void AddMental(int value)
     {
         _currentMental += value;
         if(_currentMental <= 0)

--- a/Assets/Resources/Script/PlayScene/Charactor/Player.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Player.cs
@@ -7,8 +7,6 @@ using UnityEngine.Tilemaps;
 public class Player : Charactor
 {
     // UI 및 타일 정보
-    public Image O2Gage; // 산소
-    public Image HPGage; // 체력
     public Image MTGage; // 멘탈
     public GameObject UI_Actives; // 행동 버튼 UI
     public GameObject UI_ToolBtns; // 도구 버튼 UI
@@ -69,10 +67,9 @@ public class Player : Charactor
         float ver = Input.GetAxisRaw("Vertical");
 
         //구조 상태가 아니며, 현재 체력과 산소가 남아있는 현재 조종중인 캐릭터를 Translate로 이동시킨다.
-        if (_currento2 > 0.0f && GameMgr.Instance.CurrentChar == _playerNum && _currentHp > 0.0f && _playerAct != _Act.Rescue && _currentMental > 0)
+        if (CurrentO2 > 0.0f && GameMgr.Instance.CurrentChar == _playerNum && CurrentHP > 0.0f && _playerAct != _Act.Rescue && _currentMental > 0)
         {
             this.transform.Translate(hor * Time.deltaTime * _movespeed, ver * Time.deltaTime * _movespeed, 0.0f);
-            O2Gage.fillAmount = _currento2 / _maxo2; // 산소 UI 변화
             if (GameMgr.Instance.CheckEmberTick()) // 작은 불 재생성
             {
                 for (int i = 0; i < GameMgr.Instance.UsedEmberCount; i++) // 기존에 있던 작은불들 Active false
@@ -87,13 +84,13 @@ public class Player : Charactor
             }
             if (hor != 0.0f) // 좌, 우 이동중이라면
             {
-                AddO2(-(_useo2 * Time.deltaTime));
+                AddO2(-(UseO2 * Time.deltaTime));
                 GameMgr.Instance.EmberTime += Time.deltaTime / 2; // 작은불 재생성 시간 증가
                 _moveDir = new Vector3(hor, 0, 0); // 바라보는 방향 변경
             }
             if (ver != 0.0f) //상, 하 이동중이라면
             {
-                AddO2(-(_useo2 * Time.deltaTime));
+                AddO2(-(UseO2 * Time.deltaTime));
                 GameMgr.Instance.EmberTime += Time.deltaTime / 2; // 작은불 재생성 시간 증가
             }
             //if (_currentTilePos != _tileLayout.WorldToCell(transform.position))
@@ -345,7 +342,6 @@ public class Player : Charactor
             break;
         }
 
-        HPGage.fillAmount = _currentHp / _maxHp; // 체력 UI 감소
         ChangeMentalText(); // 멘탈 UI 변경
         ChangeStateText(); // 상태 UI 변경
     }

--- a/Assets/Resources/Script/PlayScene/Charactor/Rescuer.cs
+++ b/Assets/Resources/Script/PlayScene/Charactor/Rescuer.cs
@@ -17,22 +17,17 @@ public class Rescuer : Player
     public override void ActiveSkill()
     {
         base.ActiveSkill();
+        Debug.Log("구조맨 스킬 사용");
         int range = 5;
+        int offset = -(range / 2);
         Vector3Int nPos = GameMgr.Instance.RescueTilemap.WorldToCell(transform.position);
-        for(int i=0; i<range;i++)
+        for(int i= offset; i<range + offset;i++)
         {
-            for(int j=0; j<range; j++)
+            for(int j= offset; j<range + offset; j++)
             {
-                if(GameMgr.Instance.RescueTilemap.GetTile(nPos + new Vector3Int(i, j, 0)) != null)
+                if(TileMgr.Instance.RescueTargets.ContainsKey(nPos + new Vector3Int(i, j, 0)))
                 {
-                    int RescueLayer = 1 << LayerMask.NameToLayer("Rescue"); // 생존자의 Layer
-                    RaycastHit2D hit = Physics2D.Raycast(GameMgr.Instance.RescueTilemap.CellToWorld(nPos + new Vector3Int(i, j, 0)), Vector3.back, range, RescueLayer); // 레이캐스트 쏘기
-                    if (hit)
-                    {
-                        if (hit.transform.CompareTag("RescueTarget")) // 레이캐스트 충돌 대상이 구조대상이라면
-                        {
-                        }
-                    }
+                    TileMgr.Instance.RescueTargets[nPos + new Vector3Int(i, j, 0)].ActiveSmileMark();
                 }
             }
         }

--- a/Assets/Resources/Script/PlayScene/GameMgr.cs
+++ b/Assets/Resources/Script/PlayScene/GameMgr.cs
@@ -18,44 +18,46 @@ public class GameMgr : MonoBehaviour
             return _instance;
         }
     }
-    //안녕?
+
+
     public int GameTurn = 0; // 게임 턴
-    public Player[] Comp_Players; // 사용할 캐릭터들의 Componentsㄴ
+    public Player[] Comp_Players; // 사용할 캐릭터들의 Components
     private int _currentChar = 0; // 현재 사용중인 캐릭터의 번호
-    public int CurrentChar
-    {
-        get { return _currentChar; }
-        set { _currentChar = value; }
-    } // CurrentChar Property
     private float _EmberTime = 0.0f; // 작은 불 생성 주기
-    public float EmberTime
-    {
-        get { return _EmberTime; }
-        set { _EmberTime = value; }
-    } // 작은 불 생성 주기Property
     private int _usedEmberCount = 0; // 현재 사용중인 작은 불의 숫자
-    public int UsedEmberCount
-    {
-        get { return _usedEmberCount; }
-        set { _usedEmberCount = value; }
-    } //현재 사용중인 작은 불의 숫자 Property
     public Transform Embers; // 작은 불의 부모 오브젝트의 Transform
     public GameObject Ember; // 작은 불 Prefab
-    public Transform RescueTargets; // 생존자의 부모 오브젝트
     public Tilemap BackTile; // Background Tilemap
     public Tilemap Obstacle; // Obstacel Tilemap
     public Tilemap RescueTilemap; // RescueTarget Tilemap
 
-    private RescueTarget[] _RTs; // 생존자들의 Components
     [SerializeField]
     private Text _timerText = null; // 시계 UI
     private int _minute; // 게임 상의 시간
 
     private int _stage = 0;
+
     public int stage {
         get { return _stage; }
     }
 
+    public int CurrentChar
+    {
+        get { return _currentChar; }
+        set { _currentChar = value; }
+    } // CurrentChar Property
+
+    public float EmberTime
+    {
+        get { return _EmberTime; }
+        set { _EmberTime = value; }
+    } // 작은 불 생성 주기Property
+
+    public int UsedEmberCount
+    {
+        get { return _usedEmberCount; }
+        set { _usedEmberCount = value; }
+    } //현재 사용중인 작은 불의 숫자 Property
     private void Awake()
     {
         if(_instance == null)
@@ -81,7 +83,6 @@ public class GameMgr : MonoBehaviour
         //        }
         //    }
         //}
-        _RTs = RescueTargets.GetComponentsInChildren<RescueTarget>(); // 생존자 Components 할당
         _minute = 1189; // 게임 상의 시간
     }
 
@@ -109,9 +110,9 @@ public class GameMgr : MonoBehaviour
             TileMgr.Instance.Fires[i].SpreadFire();
         }
         GameTurn++; // 턴 증가
-        for (int i = 0; i < _RTs.Length; i++) // 생존자들의 턴 종료 행동 함수 호출
+        foreach(var rt in TileMgr.Instance.RescueTargets) // 생존자 턴 종료 이동
         {
-            _RTs[i].TurnEndActive();
+             rt.Value.TurnEndActive();
         }
         Debug.Log(GameTurn + "TurnEnd");
         _minute += 5;

--- a/Assets/Resources/Script/PlayScene/Objects/RescueTarget.cs
+++ b/Assets/Resources/Script/PlayScene/Objects/RescueTarget.cs
@@ -49,7 +49,7 @@ public class RescueTarget : Charactor
     {
         if (other.CompareTag("Fire"))
         {
-            SetCurrentHP(-25.0f);
+            AddHP(-25.0f);
             HPGage.fillAmount = _currentHp / _maxHp;
             if(_currentHp / _maxHp < 0.5f && _RescueTargetState == _state.Panic)
             {
@@ -59,7 +59,7 @@ public class RescueTarget : Charactor
         }
         else if (other.CompareTag("Ember"))
         {
-            SetCurrentHP(-25.0f);
+            AddHP(-25.0f);
             HPGage.fillAmount = _currentHp / _maxHp;
             if (_currentHp / _maxHp < 0.5f && _RescueTargetState == _state.Panic)
             {
@@ -134,20 +134,11 @@ public class RescueTarget : Charactor
         _panicMoveCount = 2;
         Debug.Log("Panic Done");
     }
-    public override void SetCurrentHP(float value)
+    public override void AddHP(float value)
     {
-        _currentHp += value;
-        if (_currentHp <= 0)
-        {
-            Destroy(gameObject);
-        }
-        else if (_currentHp > _maxHp)
-        {
-            _currentHp = _maxHp;
-        }
-    }
+        base.AddHP(value);
 
-    public override void SetCurrentO2(float value)
-    {
+        if (CurrentHP <= 0)
+            Destroy(gameObject);
     }
 }

--- a/Assets/Resources/Script/PlayScene/Objects/RescueTarget.cs
+++ b/Assets/Resources/Script/PlayScene/Objects/RescueTarget.cs
@@ -4,9 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Tilemaps;
 
-public class RescueTarget : Charactor
-{
-    public Image HPGage;
+public class RescueTarget : Charactor {
     public GameObject SmileMark;
 
     private enum _state { Panic, Static }
@@ -26,6 +24,7 @@ public class RescueTarget : Charactor
     protected override void Start()
     {
         base.Start();
+
         switch(_RescueTargetState)
         {
             case _state.Panic:
@@ -50,8 +49,7 @@ public class RescueTarget : Charactor
         if (other.CompareTag("Fire"))
         {
             AddHP(-25.0f);
-            HPGage.fillAmount = _currentHp / _maxHp;
-            if(_currentHp / _maxHp < 0.5f && _RescueTargetState == _state.Panic)
+            if(CurrentHP / MaxHP < 0.5f && _RescueTargetState == _state.Panic)
             {
                 _rescueCount++;
                 _RescueTargetState = _state.Static;
@@ -60,8 +58,7 @@ public class RescueTarget : Charactor
         else if (other.CompareTag("Ember"))
         {
             AddHP(-25.0f);
-            HPGage.fillAmount = _currentHp / _maxHp;
-            if (_currentHp / _maxHp < 0.5f && _RescueTargetState == _state.Panic)
+            if (CurrentHP / MaxHP < 0.5f && _RescueTargetState == _state.Panic)
             {
                 _rescueCount++;
                 _RescueTargetState = _state.Static;

--- a/Assets/Resources/Script/PlayScene/TileMgr.cs
+++ b/Assets/Resources/Script/PlayScene/TileMgr.cs
@@ -9,7 +9,8 @@ public class TileMgr // 하이어라키에 존재하지 않는 싱글톤이라 U
     public List<Wall> Walls; // 현재 생성된 Wall Instance의 Components
     public Dictionary<Vector3Int, Electric> Electrics;
     public Dictionary<Vector3Int, Water> Waters;
-    
+    public Dictionary<Vector3Int, RescueTarget> RescueTargets;
+
     private Dictionary<Vector3Int, InteractiveObject> m_interactiveObjects;
 
     private static readonly List<Dictionary<Vector3Int, Vector3Int>> DoorPairs = new List<Dictionary<Vector3Int, Vector3Int>>(){
@@ -42,6 +43,7 @@ public class TileMgr // 하이어라키에 존재하지 않는 싱글톤이라 U
         Walls = new List<Wall>();
         Electrics = new Dictionary<Vector3Int, Electric>();
         Waters = new Dictionary<Vector3Int, Water>();
+        RescueTargets = new Dictionary<Vector3Int, RescueTarget>();
 
         m_interactiveObjects = new Dictionary<Vector3Int, InteractiveObject>();
     }

--- a/Assets/Resources/Script/PlayScene/Tiles/RescueTargetSpawnTile.cs
+++ b/Assets/Resources/Script/PlayScene/Tiles/RescueTargetSpawnTile.cs
@@ -1,0 +1,31 @@
+﻿using UnityEditor;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public class RescueTargetSpawnTile : Tile
+{
+    public override bool StartUp(Vector3Int position, ITilemap tilemap, GameObject go)
+    {
+        if (go != null)
+        {
+            RescueTarget rt = go.GetComponent<RescueTarget>();
+            if (!TileMgr.Instance.RescueTargets.ContainsKey(position))
+                TileMgr.Instance.RescueTargets.Add(position, rt);
+        }
+
+        return base.StartUp(position, tilemap, go);
+    }
+
+#if UNITY_EDITOR
+    [MenuItem("Assets/Create/Tiles/RescueTargetSpawnTile")]
+    public static void CreateElectricTile()
+    {
+        string path = EditorUtility.SaveFilePanelInProject("Save RescueTargetSpawnTile", "New RescueTargetSpawnTile", "asset", "Save RescueTargetSpawnTile", "Assets");
+        if (path == "")
+        {
+            return;
+        }
+        AssetDatabase.CreateAsset(ScriptableObject.CreateInstance<RescueTargetSpawnTile>(), path);
+    }
+#endif
+}

--- a/Assets/Resources/Script/PlayScene/Tiles/RescueTargetSpawnTile.cs.meta
+++ b/Assets/Resources/Script/PlayScene/Tiles/RescueTargetSpawnTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5e3b59ce7b5aa94d8861efa729f8139
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Tilemap/RescueTarget/RescueTargetSpawnTile.asset
+++ b/Assets/Resources/Tilemap/RescueTarget/RescueTargetSpawnTile.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: RescueTarget
+  m_Script: {fileID: 11500000, guid: e5e3b59ce7b5aa94d8861efa729f8139, type: 3}
+  m_Name: RescueTargetSpawnTile
   m_EditorClassIdentifier: 
   m_Sprite: {fileID: 21300000, guid: c08deca75e2ca5449b121ea6fac0fadb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -31,6 +31,7 @@ MonoBehaviour:
     e31: 0
     e32: 0
     e33: 1
-  m_InstancedGameObject: {fileID: 0}
+  m_InstancedGameObject: {fileID: 2783329904084916213, guid: c046d534042e88d48889bb0826057731,
+    type: 3}
   m_Flags: 1
   m_ColliderType: 1

--- a/Assets/Resources/Tilemap/RescueTarget/RescueTargetSpawnTile.asset.meta
+++ b/Assets/Resources/Tilemap/RescueTarget/RescueTargetSpawnTile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7de1e02135fcf74f9e33942778e8244
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Tilemap/SpawnPoint.prefab
+++ b/Assets/Resources/Tilemap/SpawnPoint.prefab
@@ -1,0 +1,212 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2911545149193521591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5191097875784728497}
+  - component: {fileID: 2848917802601982546}
+  - component: {fileID: 2995230724308976525}
+  m_Layer: 31
+  m_Name: Layer1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5191097875784728497
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2911545149193521591}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5366722538649498949}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1839735485 &2848917802601982546
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2911545149193521591}
+  m_Enabled: 1
+  m_Tiles:
+  - first: {x: 0, y: 2, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 0
+      m_AllTileFlags: 1073741825
+  m_AnimatedTiles: {}
+  m_TileAssetArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: f7de1e02135fcf74f9e33942778e8244, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: c08deca75e2ca5449b121ea6fac0fadb, type: 3}
+  m_TileMatrixArray:
+  - m_RefCount: 1
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 1
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  m_TileObjectToInstantiateArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 2783329904084916213, guid: c046d534042e88d48889bb0826057731,
+      type: 3}
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 3, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!483693784 &2995230724308976525
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2911545149193521591}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!1 &4272823238680046569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5366722538649498949}
+  - component: {fileID: 2823273227171217061}
+  m_Layer: 31
+  m_Name: SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5366722538649498949
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4272823238680046569}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5191097875784728497}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!156049354 &2823273227171217061
+Grid:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4272823238680046569}
+  m_Enabled: 1
+  m_CellSize: {x: 128, y: 128, z: 0}
+  m_CellGap: {x: 0, y: 0, z: 0}
+  m_CellLayout: 0
+  m_CellSwizzle: 0
+--- !u!114 &-3412841203530555125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 12395, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: Palette Settings
+  m_EditorClassIdentifier: 
+  cellSizing: 100

--- a/Assets/Resources/Tilemap/SpawnPoint.prefab.meta
+++ b/Assets/Resources/Tilemap/SpawnPoint.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: fd9aac6ff3f82cb439c9a8e6d5da096d
-NativeFormatImporter:
+guid: 53115f2f0ff09e54583ad3d30cb2b98e
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -151,75 +151,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &67424981
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 875876662}
-    m_Modifications:
-    - target: {fileID: 2783329904084916213, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_Name
-      value: panicRescueTarget
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 569
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 195
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c046d534042e88d48889bb0826057731, type: 3}
 --- !u!1 &75013619
 GameObject:
   m_ObjectHideFlags: 0
@@ -1572,7 +1503,6 @@ MonoBehaviour:
   - {fileID: 7136588880983307136}
   Embers: {fileID: 60259334}
   Ember: {fileID: 511650357875400263, guid: 928d38f504aecbe40881fcdd121ce6fd, type: 3}
-  RescueTargets: {fileID: 875876662}
   BackTile: {fileID: 881953487}
   Obstacle: {fileID: 1579761820}
   RescueTilemap: {fileID: 1482609707}
@@ -1773,8 +1703,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1677455752}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5184,7 +5113,7 @@ TilemapRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_ChunkCullingBounds: {x: 63.5, y: 63.5, z: 0}
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
@@ -5199,17 +5128,71 @@ Tilemap:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1482609704}
   m_Enabled: 1
-  m_Tiles: {}
+  m_Tiles:
+  - first: {x: 5, y: 1, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 6, y: 3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 0
+      m_AllTileFlags: 1073741825
   m_AnimatedTiles: {}
-  m_TileAssetArray: []
-  m_TileSpriteArray: []
-  m_TileMatrixArray: []
-  m_TileColorArray: []
-  m_TileObjectToInstantiateArray: []
+  m_TileAssetArray:
+  - m_RefCount: 3
+    m_Data: {fileID: 11400000, guid: f7de1e02135fcf74f9e33942778e8244, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 3
+    m_Data: {fileID: 21300000, guid: c08deca75e2ca5449b121ea6fac0fadb, type: 3}
+  m_TileMatrixArray:
+  - m_RefCount: 3
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 3
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  m_TileObjectToInstantiateArray:
+  - m_RefCount: 3
+    m_Data: {fileID: 2783329904084916213, guid: c046d534042e88d48889bb0826057731,
+      type: 3}
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Origin: {x: 0, y: 0, z: 0}
-  m_Size: {x: 0, y: 0, z: 1}
+  m_Size: {x: 7, y: 4, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -5926,12 +5909,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1641030266}
   m_CullTransparentMesh: 0
---- !u!4 &1677455752 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8635382066817374013, guid: c046d534042e88d48889bb0826057731,
-    type: 3}
-  m_PrefabInstance: {fileID: 67424981}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1708870341
 GameObject:
   m_ObjectHideFlags: 0
@@ -7106,6 +7083,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e4913cfa88bcb0459460b63ccad91ed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _maxo2: 70
+  _useo2: 2
+  _maxHp: 60
   O2Gage: {fileID: 3160156809655150969}
   HPGage: {fileID: 3160156809655150968}
   MTGage: {fileID: 3160156809655150967}
@@ -7116,9 +7096,6 @@ MonoBehaviour:
   FireWallTile: {fileID: 11400000, guid: d997ec2becf2f80469d2e8829c8c6d3d, type: 2}
   _playerNum: 2
   _movespeed: 500
-  _maxo2: 70
-  _useo2: 2
-  _maxHp: 60
   _maxMental: 4
   _body: {fileID: 3160156809655150965}
 --- !u!1001 &7136588880983307127
@@ -7339,6 +7316,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec3441f00f340f044b297b464e19c37c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _maxo2: 70
+  _useo2: 2
+  _maxHp: 60
   O2Gage: {fileID: 7136588880983307133}
   HPGage: {fileID: 7136588880983307132}
   MTGage: {fileID: 7136588880983307131}
@@ -7349,9 +7329,6 @@ MonoBehaviour:
   FireWallTile: {fileID: 11400000, guid: d997ec2becf2f80469d2e8829c8c6d3d, type: 2}
   _playerNum: 3
   _movespeed: 500
-  _maxo2: 70
-  _useo2: 2
-  _maxHp: 60
   _maxMental: 4
   _body: {fileID: 7136588880983307129}
 --- !u!1001 &7274700534510155483


### PR DESCRIPTION
- Player와 RescueTarget의 상속을 Charactor로 바꿨습니다.
- Charactor를 사용하기 위해선 SetCurrentHP(float), SetCurrent02(float)를 반드시 구현해야합니다.
- 생존자의 Component를 담는 Container를 기존 GameMgr의 RTs[], RescueTargets에서 TileMgr의 Dictionary로 변경하였습니다.
- 구조맨의 스킬을 구현하였습니다.